### PR TITLE
Bug final newline causing body parsing to fail

### DIFF
--- a/microstomp.py
+++ b/microstomp.py
@@ -2,8 +2,8 @@
 Written as a patch-in for Stomp.py for Micropython.
 '''
 
-import socket as usocket
-import time as utime
+import usocket
+import utime
 
 class Frame:
     '''


### PR DESCRIPTION
When newline character was in a terminating position, that is after the null character (x00), the value of the newline character would be greater than the null character, failing the body parsing to fail. This PR resolves that by adding a conditional to check for this case and then reevaluate by removing the terminating newline.

Also: the invalid command error is more descriptive, by adding the incorrect command to the error message.
Removed the await response from the subscribe function.